### PR TITLE
Beware 3478 3479 is PSN Network traffic

### DIFF
--- a/dscptag.sh
+++ b/dscptag.sh
@@ -49,8 +49,8 @@ ipt64dscp -p udp --dport 10000 -j DSCP --set-dscp-class CS4
 ipt64dscp -p udp --sport 10000 -j DSCP --set-dscp-class CS4
 
 ## boost zoom to CS4
-ipt64dscp -p udp -m multiport --sports 3478:3479,8801:8802 -j DSCP --set-dscp-class CS4
-ipt64dscp -p udp -m multiport --dports 3478:3479,8801:8802 -j DSCP --set-dscp-class CS4
+ipt64dscp -p udp -m multiport --sports 8801:8802 -j DSCP --set-dscp-class CS4
+ipt64dscp -p udp -m multiport --dports 8801:8802 -j DSCP --set-dscp-class CS4
 
 ## boost google meet CS4
 ipt64dscp -p udp -m multiport --sports 19302:19309 -j DSCP --set-dscp-class CS4


### PR DESCRIPTION
3478:3479 will get mixed up in PSN / PlayStation Network traffic via the Zoom entry.

An idea would be to ask if the user has a PlayStation (PS3,PS4,PS5) on there network, If yes disallow 3478:3479 if not keep 3478:3479