### PR TITLE
Reduce memory accesses when using sets

### DIFF
--- a/dscptag.nft
+++ b/dscptag.nft
@@ -31,27 +31,27 @@ table inet dscptag {
     }
 
 
-    set xfst_ack {ct id
+    set xfst_ack {ct id . ct direction
         flags dynamic;
         timeout 5m
     }
-    set fast_ack {ct id
+    set fast_ack {ct id . ct direction
         flags dynamic;
         timeout 5m
     }
-    set med_ack {ct id
+    set med_ack {ct id . ct direction
         flags dynamic;
         timeout 5m
     }
-    set slow_ack {ct id
+    set slow_ack {ct id . ct direction
         flags dynamic;
         timeout 5m
     }
-    set udp_meter {ct id
+    set udp_meter {ct id . ct direction
         flags dynamic;
         timeout 5m
     }
-    set slowtcp {ct id
+    set slowtcp {ct id . ct direction
         flags dynamic;
         timeout 5m
     }
@@ -86,10 +86,10 @@ table inet dscptag {
         ip6 nexthdr tcp tcp dport $tcpbulkport ip6 dscp set cs1
 
         ## ack limit rate to about 150 pps by decimating the quantity of pure acks being sent
-        meta length < 100 tcp flags & ack == ack add @xfst_ack {ct id limit rate over 30000/second} jump drop995 
-        meta length < 100 tcp flags & ack == ack add @fast_ack {ct id limit rate over 3000/second} jump drop95
-        meta length < 100 tcp flags & ack == ack add @med_ack {ct id limit rate over 300/second} jump drop50
-        meta length < 100 tcp flags & ack == ack add @slow_ack {ct id limit rate over 300/second} jump drop50
+        meta length < 100 tcp flags & ack == ack add @xfst_ack {ct id . ct direction limit rate over 30000/second} jump drop995
+        meta length < 100 tcp flags & ack == ack add @fast_ack {ct id . ct direction limit rate over 3000/second} jump drop95
+        meta length < 100 tcp flags & ack == ack add @med_ack {ct id . ct direction limit rate over 300/second} jump drop50
+        meta length < 100 tcp flags & ack == ack add @slow_ack {ct id . ct direction limit rate over 300/second} jump drop50
         ## for almost everyone we won't send more than 150-400 acks/second
 
         ip protocol udp udp dport $vidconfports ip dscp set cs4
@@ -108,8 +108,8 @@ table inet dscptag {
         ip6 nexthdr udp ip6 saddr $lowpriolan6 ip6 dscp set cs2
 
         #downgrade udp going faster than 450 pps, probably not realtime traffic
-        ip protocol udp ip dscp > cs2 add @udp_meter {ct id limit rate over 450/second} counter ip dscp set cs2
-        ip6 nexthdr udp ip6 dscp > cs2 add @udp_meter {ct id limit rate over 450/second} counter ip6 dscp set cs2
+        ip protocol udp ip dscp > cs2 add @udp_meter {ct id . ct direction limit rate over 450/second} counter ip dscp set cs2
+        ip6 nexthdr udp ip6 dscp > cs2 add @udp_meter {ct id . ct direction limit rate over 450/second} counter ip6 dscp set cs2
 
         # down prioritize the first 500ms of tcp packets
         ip protocol tcp ct bytes < $first500ms ip dscp < cs4 ip dscp set cs2
@@ -118,8 +118,8 @@ table inet dscptag {
         ip protocol tcp ct bytes > $first10s ip dscp < cs4 ip dscp set cs1
 
         ## tcp with less than 150 pps gets upgraded to cs4
-        ip protocol tcp add @slowtcp {ct id limit rate 150/second burst 150 packets } ip dscp set cs4
-        ip6 nexthdr tcp add @slowtcp {ct id limit rate 150/second burst 150 packets} ip6 dscp set cs4
+        ip protocol tcp add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets } ip dscp set cs4
+        ip6 nexthdr tcp add @slowtcp {ct id . ct direction limit rate 150/second burst 150 packets} ip6 dscp set cs4
 
         ## classify for the HFSC queues:
         meta priority set ip dscp map @priomap

--- a/dscptag.nft
+++ b/dscptag.nft
@@ -31,35 +31,27 @@ table inet dscptag {
     }
 
 
-    set xfst4ack { typeof ip daddr . ip saddr . tcp dport . tcp sport
+    set xfst_ack {ct id
         flags dynamic;
         timeout 5m
     }
-    set fast4ack { typeof ip daddr . ip saddr . tcp dport . tcp sport
+    set fast_ack {ct id
         flags dynamic;
         timeout 5m
     }
-    set med4ack { typeof ip daddr . ip saddr . tcp dport . tcp sport
+    set med_ack {ct id
         flags dynamic;
         timeout 5m
     }
-    set slow4ack { typeof ip daddr . ip saddr . tcp dport . tcp sport
+    set slow_ack {ct id
         flags dynamic;
         timeout 5m
     }
-    set udp_meter4 {typeof ip saddr . ip daddr . udp sport . udp dport
+    set udp_meter {ct id
         flags dynamic;
         timeout 5m
     }
-    set udp_meter6 {typeof ip6 saddr . ip6 daddr . udp sport . udp dport
-        flags dynamic;
-        timeout 5m
-    }
-    set slowtcp4 {typeof ip saddr . ip daddr . tcp sport . tcp dport
-        flags dynamic;
-        timeout 5m
-    }
-    set slowtcp6 {typeof ip6 saddr . ip6 daddr . tcp sport . tcp dport
+    set slowtcp {ct id
         flags dynamic;
         timeout 5m
     }
@@ -94,10 +86,10 @@ table inet dscptag {
         ip6 nexthdr tcp tcp dport $tcpbulkport ip6 dscp set cs1
 
         ## ack limit rate to about 150 pps by decimating the quantity of pure acks being sent
-        ip protocol tcp tcp flags & ack == ack meta length < 100 add @xfst4ack {ip daddr . ip saddr . tcp dport . tcp sport limit rate over 30000/second} jump drop995 
-        ip protocol tcp tcp flags & ack == ack meta length < 100 add @fast4ack {ip daddr . ip saddr . tcp dport . tcp sport limit rate over 3000/second} jump drop95
-        ip protocol tcp tcp flags & ack == ack meta length < 100 add @med4ack {ip daddr . ip saddr . tcp dport . tcp sport limit rate over 300/second} jump drop50
-        ip protocol tcp tcp flags & ack == ack meta length < 100 add @slow4ack {ip daddr . ip saddr . tcp dport . tcp sport limit rate over 300/second} jump drop50
+        meta length < 100 tcp flags & ack == ack add @xfst_ack {ct id limit rate over 30000/second} jump drop995 
+        meta length < 100 tcp flags & ack == ack add @fast_ack {ct id limit rate over 3000/second} jump drop95
+        meta length < 100 tcp flags & ack == ack add @med_ack {ct id limit rate over 300/second} jump drop50
+        meta length < 100 tcp flags & ack == ack add @slow_ack {ct id limit rate over 300/second} jump drop50
         ## for almost everyone we won't send more than 150-400 acks/second
 
         ip protocol udp udp dport $vidconfports ip dscp set cs4
@@ -116,8 +108,8 @@ table inet dscptag {
         ip6 nexthdr udp ip6 saddr $lowpriolan6 ip6 dscp set cs2
 
         #downgrade udp going faster than 450 pps, probably not realtime traffic
-        ip protocol udp ip dscp > cs2 add @udp_meter4 {ip saddr . ip daddr . udp sport . udp dport limit rate over 450/second} counter ip dscp set cs2
-        ip6 nexthdr udp ip6 dscp > cs2 add @udp_meter6 {ip6 saddr . ip6 daddr . udp sport . udp dport limit rate over 450/second} counter ip6 dscp set cs2
+        ip protocol udp ip dscp > cs2 add @udp_meter {ct id limit rate over 450/second} counter ip dscp set cs2
+        ip6 nexthdr udp ip6 dscp > cs2 add @udp_meter {ct id limit rate over 450/second} counter ip6 dscp set cs2
 
         # down prioritize the first 500ms of tcp packets
         ip protocol tcp ct bytes < $first500ms ip dscp < cs4 ip dscp set cs2
@@ -126,8 +118,8 @@ table inet dscptag {
         ip protocol tcp ct bytes > $first10s ip dscp < cs4 ip dscp set cs1
 
         ## tcp with less than 150 pps gets upgraded to cs4
-        ip protocol tcp add @slowtcp4 {ip saddr . ip daddr . tcp sport . tcp dport limit rate 150/second burst 150 packets } ip dscp set cs4
-        ip6 nexthdr tcp add @slowtcp6 {ip6 saddr . ip6 daddr . tcp sport . tcp dport limit rate 150/second burst 150 packets} ip6 dscp set cs4
+        ip protocol tcp add @slowtcp {ct id limit rate 150/second burst 150 packets } ip dscp set cs4
+        ip6 nexthdr tcp add @slowtcp {ct id limit rate 150/second burst 150 packets} ip6 dscp set cs4
 
         ## classify for the HFSC queues:
         meta priority set ip dscp map @priomap


### PR DESCRIPTION
Use more efficient (smaller) nftables conntrack id in place of iptables-translate 4-tupple

Consequentially avoid extracting large piles of data from packet payload

Unify ipv4 and ipv6 meters as now they are same type and certainly unique to eachother

And enable ack rate-limiting for ipv6 using same meter at no extra processing cost.

Roughly equals to https://github.com/hudra0/qosmate/pull/7 , most impactful part of qosmate  0.5.32-> 0.5.34

Signed-off-by: Andris PE <neandris@gmail.com>