### PR TITLE
[bugfix] Avoid re-prioritizing tcpbulk cs1

### DIFF
--- a/dscptag.nft
+++ b/dscptag.nft
@@ -126,8 +126,8 @@ table inet dscptag {
         ip protocol tcp ct bytes > $first10s ip dscp < cs4 ip dscp set cs1
 
         ## tcp with less than 150 pps gets upgraded to cs4
-        ip protocol tcp add @slowtcp4 {ip saddr . ip daddr . tcp sport . tcp dport limit rate 150/second burst 150 packets } ip dscp set cs4
-        ip6 nexthdr tcp add @slowtcp6 {ip6 saddr . ip6 daddr . tcp sport . tcp dport limit rate 150/second burst 150 packets} ip6 dscp set cs4
+        ip protocol tcp add @slowtcp4 {ip saddr . ip daddr . tcp sport . tcp dport limit rate 150/second burst 150 packets } ip dscp != cs1 ip dscp set cs4
+        ip6 nexthdr tcp add @slowtcp6 {ip6 saddr . ip6 daddr . tcp sport . tcp dport limit rate 150/second burst 150 packets} ip6 dscp != cs1 ip6 dscp set cs4
 
         ## classify for the HFSC queues:
         meta priority set ip dscp map @priomap

--- a/dscptag.nft
+++ b/dscptag.nft
@@ -120,7 +120,7 @@ table inet dscptag {
         ip6 nexthdr udp ip6 dscp > cs2 add @udp_meter6 {ip6 saddr . ip6 daddr . udp sport . udp dport limit rate over 450/second} counter ip6 dscp set cs2
 
         # down prioritize the first 500ms of tcp packets
-        ip protocol tcp ct bytes < $first500ms ip dscp < cs4 ip dscp set cs2
+        ip protocol tcp ct bytes < $first500ms ip dscp < cs4 ip dscp != cs1 ip dscp set cs2
 
         # downgrade tcp that has transferred more than 10 seconds worth of packets
         ip protocol tcp ct bytes > $first10s ip dscp < cs4 ip dscp set cs1


### PR DESCRIPTION
In present code ip4 tcp bulk priority is neutralized in connection ageing code, lets make it right,
See https://github.com/hudra0/qosmate/pull/17/files for more optimized version.

Signed-off-by: Andris PE <neandris@gmail.com>